### PR TITLE
Fixed flickering hidden buttons

### DIFF
--- a/plugins/ALOE_VirtualButtons.js
+++ b/plugins/ALOE_VirtualButtons.js
@@ -675,7 +675,10 @@ var ALOE = ALOE || {};
         this._delayCounter++;
       } else {
         this.opacity -= 255 / this._duration;
-        if (this.opacity <= 0) this._delayCounter = 0;
+        if (this.opacity <= 0) {
+          this._delayCounter = 0;
+          this._showing = false;
+        }
       }
     } else if (this._showing && this.opacity < 255) {
       if (this._delayCounter < this._delay) {

--- a/source_code/ALOE_VirtualButtons.js
+++ b/source_code/ALOE_VirtualButtons.js
@@ -651,7 +651,10 @@ var ALOE = ALOE || {};
 				this._delayCounter++;
 			} else {
 				this.opacity -= 255 / this._duration;
-				if (this.opacity <= 0) this._delayCounter = 0;
+				if (this.opacity <= 0) {
+					this._delayCounter = 0;
+					this._showing = false;
+				}
 			}
 		} else if (this._showing && this.opacity < 255) {
 			if (this._delayCounter < this._delay) {


### PR DESCRIPTION
There was an infinite loop cause by not setting this._showing false on buttons when they hit opacity <= 0. I've closed the loop in the source code and es5 versions for this pull request. I made the edit to plugins folder version manually because I don't want to download dependencies for the sake of legacy code. I'm not sure if that caused a necessary step to be skipped. I have a client who wanted this fixed and I noticed you lost interest and left little access to the buttons from other plugins. I could have accessed the buttons through scene_base and aliased the update visibility every time a button was created but hey.. everyone can use this fix. It's a good plugin. If you ever decide to take it up again. I would like to see destination x/y plugin parameters for each button rather than just collapsing them to the control button.

Here are some pictures to illustrate what this pull request solves,10fps but gets the point across: 

bug: fade 0, key button clicked because it's over control button
![bug_with_fade_0](https://user-images.githubusercontent.com/980081/71218155-7ad98e80-228e-11ea-99a5-41ba1528b17c.gif)

fix: fade 0
![fix_fade_0](https://user-images.githubusercontent.com/980081/71218183-8cbb3180-228e-11ea-8cc5-9bb9f626f221.gif)

bug: fade 20, flicker less noticed because opacity = (255 / 20), doesn't click( didn't check why).
![bug_with_fade_20](https://user-images.githubusercontent.com/980081/71218271-da379e80-228e-11ea-95fe-6e224385e629.gif)

fix: fade 20
![fix_with_fade_20](https://user-images.githubusercontent.com/980081/71218331-15d26880-228f-11ea-8d82-825c35fea839.gif)
